### PR TITLE
Update Wolowitz.pm

### DIFF
--- a/lib/Dancer/Plugin/Locale/Wolowitz.pm
+++ b/lib/Dancer/Plugin/Locale/Wolowitz.pm
@@ -101,6 +101,8 @@ sub _lang {
 
 sub _detect_lang_from_browser {
     my $lang = request->accept_language;
+    
+    return unless $lang;
 
     $lang =~ s/-\w+//g;
     $lang = (split(/,\s*/,$lang))[0] if $lang =~ /,/;


### PR DESCRIPTION
As it seems, not all user-agents populate the ->accept_language value. Robots? Probably. Haven't poked around in the logs...

Anyway, I've found an ugly warnings about "unitialized value in substitution" when $lang is empty in my error logs.

So let's return empty from _detect_lang_from_browser for such cases. Which should let the module->L::W fall-back onto the default lang, right?
