### PR TITLE
speedups: 3rd arg to loc(); typos

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,13 @@ Revision history for Dancer-Plugin-Locale-Wolowitz
 
 {{$NEXT}}
 
+    Speedup: less temp scalars, index instead of regex
+    Added optional third argument (force language)
+    handling to loc()
+    Shortcut lang detection on multiple loc() calls within
+    one request, when no session is used
+    Typos and such
+
 0.140120  2014-01-12 01:53:54CET+0100 Europe/Paris
 
     Few cosmetic things.

--- a/lib/Dancer/Plugin/Locale/Wolowitz.pm
+++ b/lib/Dancer/Plugin/Locale/Wolowitz.pm
@@ -65,8 +65,7 @@ sub _loc {
 }
 
 sub _path_directory_locale {
-    my $settings = plugin_setting;
-    my $path     = $settings->{locale_path_directory}
+    my $path     = plugin_setting()->{locale_path_directory}
         // Dancer::FileUtils::path(setting('appdir'), 'i18n');
 
     if ( ! -d $path ) {
@@ -77,8 +76,7 @@ sub _path_directory_locale {
 }
 
 sub _lang {
-    my $settings     = plugin_setting;
-    my $lang_session = $settings->{lang_session} || 'lang';
+    my $lang_session = plugin_setting()->{lang_session} || 'lang';
     my $lang;
     # don't force the user to store lang in a session
     if ( setting('session') ) {

--- a/lib/Dancer/Plugin/Locale/Wolowitz.pm
+++ b/lib/Dancer/Plugin/Locale/Wolowitz.pm
@@ -44,9 +44,7 @@ instead of the the second argument.
 
 add_hook(
     before_template => sub {
-        my $tokens = shift;
-
-        $tokens->{l} = sub { _loc(@_); };
+        $_[0]->{l} = sub { _loc(@_); };
     }
 );
 

--- a/lib/Dancer/Plugin/Locale/Wolowitz.pm
+++ b/lib/Dancer/Plugin/Locale/Wolowitz.pm
@@ -76,10 +76,10 @@ sub _path_directory_locale {
 }
 
 sub _lang {
-    my $lang_session = plugin_setting()->{lang_session} || 'lang';
     my $lang;
     # don't force the user to store lang in a session
     if ( setting('session') ) {
+        my $lang_session = plugin_setting()->{lang_session} || 'lang';
         my $session_language = session $lang_session;
         return $session_language if $session_language;
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -9,8 +9,6 @@ use Dancer::Test;
 use lib 't/lib';
 use TestApp;
 
-plan tests => 7;
-
 setting appdir => setting('appdir') . '/t';
 
 session lang => 'en';
@@ -19,7 +17,7 @@ is $res->{status}, 200, 'check status response';
 is $res->{content}, 'Welcome', 'check simple key english';
 
 $res = dancer_response GET => '/no_key';
-is $res->{content}, 'hello', 'check no key found english';
+is $res->{content}, 'goodbye', 'check no key found english';
 
 $res     = dancer_response GET => '/complex_key';
 my $path = setting('appdir');
@@ -30,7 +28,51 @@ $res = dancer_response GET => '/';
 is $res->{content}, 'Bienvenue', 'check simple key french';
 
 $res = dancer_response GET => '/no_key';
-is $res->{content}, 'hello', 'check no key found french';
+is $res->{content}, 'goodbye', 'check no key found french';
 
 $res = dancer_response GET => '/complex_key';
 is $res->{content}, "Repertoire $path non trouve", 'check complex key english';
+
+
+## test language auto-detect when we have no session
+## I don't see why the TestApp.pm is having a session (or in other words, why testing "if ( setting('session') ) {" in Wolowitz.pm returns true - at least in my setup)
+## diag "--- dropping session";
+## what's the right way? (couldn't get it to work in test context):
+# session lang => undef;
+# setting 'session' => undef;
+# session->destroy;
+sub todo_tests_not_working_yet {
+
+	session->destroy;
+	# two letter language code (dunno if this is RFC compliant, and ever sent by a browser)
+	$res = dancer_response( 'GET' => '/', { headers => HTTP::Headers->new('Accept_Language', 'fr') });
+	is $res->{content}, 'Bienvenue', 'check Accept-Language parsing';
+
+	session->destroy;
+	# example string from Wikipedia List_of_HTTP_header_fields
+	$res = dancer_response( 'GET' => '/', { headers => HTTP::Headers->new('Accept_Language', 'en-US') });
+	is $res->{content}, 'Welcome', 'check Accept-Language parsing';
+
+	session->destroy;
+	# example string from rfc2616-sec14: would mean: "I prefer Danish, but will accept British English and other types of English."
+	$res = dancer_response( 'GET' => '/', { headers => HTTP::Headers->new('Accept_Language' => 'da, en-gb;q=0.8, en;q=0.7') });
+	is $res->{content}, 'Velkomst', 'check Accept-Language parsing';
+
+
+	session->destroy;
+	# This test will trigger loc() twice withing the same request, so
+	# the shortcut in _detect_lang_from_browser is triggered, where we
+	# stored a previously detected lang into the request hash.
+	# This test isn't actually possible, as we'd have to inspect what's
+	# going on in Wolowitz and request(), but the route illustrates the concept
+	$res = dancer_response( 'GET' => '/twice_same_request', { headers => HTTP::Headers->new('Accept_Language' => 'da, en-gb;q=0.8, en;q=0.7') });
+	is $res->{content}, 'Velkomst Hej', 'check detection shortcut, in no-session environment';
+}
+
+## test new feature: being able to pass loc() a language, instead of leaving this to auto-detect
+is t::lib::TestApp::loc("welcome",[],'en'), "Welcome", "call loc() with forced language en";
+is t::lib::TestApp::loc("welcome",[],'fr'), "Bienvenue", "call loc() with forced language fr";
+is t::lib::TestApp::loc("welcome",[],'da'), "Velkomst", "call loc() with forced language da";
+
+
+done_testing;

--- a/t/i18n/locales.coll.json
+++ b/t/i18n/locales.coll.json
@@ -1,7 +1,13 @@
 {
     "welcome": {
         "fr": "Bienvenue",
-        "en": "Welcome"
+        "en": "Welcome",
+        "da": "Velkomst"
+    },
+    "hello": {
+        "fr": "Salut",
+        "en": "Hello",
+        "da": "Hej"
     },
     "path_not_found %1": {
         "fr": "Repertoire %1 non trouve",

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -9,7 +9,7 @@ get '/' => sub {
 };
 
 get '/no_key' => sub {
-    my $tr = loc('hello');
+    my $tr = loc('goodbye');
     return $tr;
 };
 
@@ -18,6 +18,10 @@ get '/complex_key' => sub {
     my $tr   = loc('path_not_found %1', [$path]);
 
     return $tr;
+};
+
+get '/twice_same_request' => sub {
+    return loc("welcome") .' '. loc("hello");
 };
 
 1;

--- a/xt/02-parse-lang.t
+++ b/xt/02-parse-lang.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+# This test is the internal parsing logic, separated for testing
+
+is( parse_string('fr'), 'fr');
+is( parse_string('en-US'), 'en');
+is( parse_string('da, en-gb;q=0.8, en;q=0.7'), 'da');
+is( parse_string("de-DE,en-GB;q=0.8,de;q=0.5,en;q=0.3"), 'de');
+
+done_testing;
+
+
+sub parse_string {
+    my $lang = shift;
+
+    $lang =~ s/-\w+//g;
+print "-- $lang \n";
+    $lang = (split(/,\s*/,$lang))[0] if index($lang,',');
+print "-- $lang \n";
+    return $lang;
+}


### PR DESCRIPTION
![speedup](https://cloud.githubusercontent.com/assets/1842508/11913462/dcf2a5d4-a664-11e5-8f21-cc034d10d78a.png)

Recently, when I ran NYTProf  on one of my apps, I've noticed that the Wolowitz plugin is always ending up in the upper ranks on "time consumed" (see example screenshot of an unscientific benchmark), not so good. So I dug into the code to see if there's anything which can be done to optimize things.
What I did is replacing one of the regexes with index(), and I've removed temp scalars elsewhere. Makes it less readable, but is faster, as it seems. Impact of my changes is small, would've loved to save more CPU cycles. _Anyone with better ideas?_

The other thing is: I've noticed that regexes would be called over and over in cases where the app is not having the ability to store an auto-detection result into a session. For this (rare) case there's a hack-ish fix now, where we store our result into the request hash.
Such a shortcut would be especially handy in case we'd ever have a more sophisticated (heavier) auto-detect, where the plugin handles cases where a user's first preferred language is not found, but the user's fallback languages in ACCEPT-LANGUAGE contain some language we'd offer. Right now, as you know, we're only looking at a user's primary language.

The third and last thing is I've added handling of a third argument in loc(). I've came across a case where I was using template() to compile an email, and the template contains l() calls. The thing is, in this context, I'm populating the user's/email-recipient's language preference from db, not from a browser environment, so auto-detect has nothing to detect. Locale::Wolowitz's is accepting $lang as second arg; we here feed an array-ref with interpolators to loc() as second arg. Only way out: third argument is now $lang, I hope you as well think this makes sense, although it reverses the API introduced by Wolowitz.
